### PR TITLE
Update pdfbox-box binding to version 1.8.10.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ An example app is located in the `Sample` directory and includes examples of com
 Important notes
 ===============
 
--Currently based on PdfBox-Android v1.8.10.1<br/>
+-Currently based on PdfBox-Android v1.8.10.3<br/>
 -Requires API 19 or greater for full functionality
 
 License

--- a/Sample/MainActivity.cs
+++ b/Sample/MainActivity.cs
@@ -94,16 +94,10 @@ namespace PdfBoxAndroidSample
 		{
 			// Enable Android-style asset loading (highly recommended)
 			PDFBoxResourceLoader.Init(Application.Context);
-			// Find the root of the external storage.
-			root = Environment.GetExternalStoragePublicDirectory(Environment.DirectoryDownloads);
+			// Find the root of the internal storage.
+			root = Application.Context.CacheDir;
 			assetManager = this.Assets;
 			tv = (TextView)FindViewById(Resource.Id.statusTextView);
-
-			// Need to ask for write permissions on SDK 23 and up, this is ignored on older versions
-			if (ContextCompat.CheckSelfPermission(this, Manifest.Permission.WriteExternalStorage) != Android.Content.PM.Permission.Granted)
-			{
-				ActivityCompat.RequestPermissions(this, new string[] { Manifest.Permission.WriteExternalStorage }, 1);
-			}
 		}
 
         // Creates a new PDF from scratch and saves it to a file

--- a/Xamarin.Android.PdfBox/Xamarin.Android.PdfBox.csproj
+++ b/Xamarin.Android.PdfBox/Xamarin.Android.PdfBox.csproj
@@ -69,7 +69,7 @@
     <TransformFile Include="Transforms\EnumMethods.xml" />
   </ItemGroup>
   <ItemGroup>
-    <LibraryProjectZip Include="Jars\pdfbox-android-1.8.10.1.aar" />
+    <LibraryProjectZip Include="Jars\pdfbox-android-1.8.10.3.aar" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="NuGet.Build.Packaging">


### PR DESCRIPTION
This PR updates the pdfbox-box binding to version 1.8.10.3.
I have tested it in the sample project and it's working.
This fixes https://github.com/gsgou/Xamarin.Android.PdfBox/issues/1