### PR TITLE
Allow PdfBox to run on the Android emulator

### DIFF
--- a/Sample/Sample.csproj
+++ b/Sample/Sample.csproj
@@ -24,7 +24,7 @@
     <AndroidEnableSGenConcurrent>true</AndroidEnableSGenConcurrent>
     <AndroidUseAapt2>true</AndroidUseAapt2>
     <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
-    <AndroidSupportedAbis>armeabi-v7a;arm64-v8a</AndroidSupportedAbis>
+    <AndroidSupportedAbis>armeabi-v7a;arm64-v8a;x86;x86_64</AndroidSupportedAbis>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>True</DebugSymbols>


### PR DESCRIPTION
Hi @gsgou,
It was a bit cumbersome to need to test this on a device on every release, so with this PR it becomes possible to test PdfBox on the emulator.
By the way, I'm not sure if you saw, but on Monday I released a new version that binds PdfBox 2.0.6.0.
Thanks